### PR TITLE
Change fb:admins to fb:app_id

### DIFF
--- a/eventHandlers/muraMeta.cfc
+++ b/eventHandlers/muraMeta.cfc
@@ -47,7 +47,7 @@
         </cfif>
 
         <cfif $.siteConfig().getValue("facebookID") neq ''>
-          <cfset openGraphMeta &= '  <meta property="fb:admins" content="#$.siteConfig().getValue("facebookID")#" />#NL#'>
+          <cfset openGraphMeta &= '  <meta property="fb:app_id" content="#$.siteConfig().getValue("facebookID")#" />#NL#'>
         </cfif>
       </cfdefaultcase>
     </cfswitch>

--- a/eventHandlers/muraMeta.cfc
+++ b/eventHandlers/muraMeta.cfc
@@ -43,7 +43,7 @@
         <cfset openGraphMeta &= '<meta property="article:modified_time" content="#DateFormat($.content().getLastUpdate(), "yyyy-MM-dd")#T#TimeFormat($.content().getLastUpdate(), "hh:mm:00")#+Z" />'>
 
         <cfif len($.content().getImageURL())>
-          <cfset openGraphMeta &= '  <meta property="og:image" content="#protocol##cgi.http_host##$.content().getImageURL()#" />#NL#'>
+          <cfset openGraphMeta &= '  <meta property="og:image" content="#protocol##cgi.http_host##$.content().getImageURL(size='large')#" />#NL#'>
         </cfif>
 
         <cfif $.siteConfig().getValue("facebookID") neq ''>


### PR DESCRIPTION
Update to meta property for fb:admins to fb:app_id. When using the url debugger, I found I had to change fb:admins property value to fb:app_id.